### PR TITLE
Fix the build issue

### DIFF
--- a/TouchLemmings/LemmingsScene.swift
+++ b/TouchLemmings/LemmingsScene.swift
@@ -39,7 +39,7 @@ class LemmmingsScene: SKScene, SKPhysicsContactDelegate {
   }
 
   override func touchesBegan(with event: NSEvent) {
-    if #available(OSX 10.12.1, *) {
+    if #available(OSX 10.12.2, *) {
       if let touch = event.allTouches().first {
         let location = CGPoint(x: touch.location(in: self.view).x, y: 14)
 


### PR DESCRIPTION
error: 'location(in:)' is only available on OS X 10.12.2 or newer